### PR TITLE
Pin nor.the-rn.info route in wrangler.jsonc, fix doc gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,9 @@ Image references inside templates (e.g., the site logo via `META.LOGO`) are proc
 
 ### Deployment
 
-The site deploys to a Cloudflare Worker (Workers Static Assets), not Cloudflare Pages. On push to `main`, `.github/workflows/deploy.yml` runs `npm ci`, `npm run build`, and `wrangler deploy`. The Worker entry point is `worker/index.js`; its only job is to strip the `/rm_ation/` prefix off incoming requests before forwarding to the `ASSETS` binding. Worker config lives in `wrangler.jsonc`. Required GitHub secret: `CLOUDFLARE_API_TOKEN`. Local Worker preview: `npm run build && npm run worker:dev` then open `http://localhost:8787/rm_ation/`.
+The site deploys to a Cloudflare Worker (Workers Static Assets), not Cloudflare Pages. On push to `main`, `.github/workflows/deploy.yml` runs `npm ci`, `npm run build`, and `wrangler deploy`. The Worker entry point is `worker/index.js`; its only job is to strip the `/rm_ation/` prefix off incoming requests before forwarding to the `ASSETS` binding. Worker config lives in `wrangler.jsonc`, including the `routes` block that binds the Worker to `nor.the-rn.info/*` on the `the-rn.info` zone. Required GitHub secret: `CLOUDFLARE_API_TOKEN`. Local Worker preview: `npm run build && npm run worker:dev` then open `http://localhost:8787/rm_ation/`.
+
+Note: the `www.the-rn.info/*` and `the-rn.info/*` zone routes are still bound to a separate, pre-existing Worker (`northern-information-sentinel`) that predates this migration. Those are out of scope for the static-assets Worker.
 
 ## Accessibility
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Scaffolds blog posts from new entries in `@tyleretters/discography`. See `script
 
 Automatic on push to `main` via GitHub Actions (`.github/workflows/deploy.yml`). The workflow runs `npm ci`, then `npm run build`, then `wrangler deploy` to push `dist/` to a Cloudflare Worker (`northern-information`) using Workers Static Assets.
 
-The Worker code is a thin shim at `worker/index.js`: it strips the `/rm_ation/` prefix from incoming requests and forwards to the `ASSETS` binding. Config is in `wrangler.jsonc`.
+The Worker code is a thin shim at `worker/index.js`: it strips the `/rm_ation/` prefix from incoming requests and forwards to the `ASSETS` binding. Config is in `wrangler.jsonc`, which also pins the production hostname binding (`nor.the-rn.info/*`) via a Workers Route on the `the-rn.info` zone.
 
 Required GitHub Actions secret: `CLOUDFLARE_API_TOKEN`. Create it in the Cloudflare dashboard under Manage Account → Account API Tokens → Create Token, using the **Edit Cloudflare Workers** template. Scope the account and zone resources down to this site.
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -12,5 +12,11 @@
   },
   "observability": {
     "enabled": true
-  }
+  },
+  "routes": [
+    {
+      "pattern": "nor.the-rn.info/*",
+      "zone_name": "the-rn.info"
+    }
+  ]
 }


### PR DESCRIPTION
Follow-up to #3 after the live cutover surfaced two things the original migration got wrong about.

- The production `/rm_ation/` rewrite was **not** a Cloudflare route rewrite (Transform Rule / Page Rule). It was a separate Worker, `northern-information-sentinel`, bound to three zone routes (`the-rn.info/*`, `www.the-rn.info/*`, `nor.the-rn.info/*`). The cutover repointed only `nor.the-rn.info/*` to the new `northern-information` Worker; the other two are still served by the sentinel.
- That hostname binding existed only as out-of-band dashboard state (created via API during cutover). Future `wrangler deploy` runs would not reaffirm it.

## Changes

- `wrangler.jsonc`: add a `routes` block declaring `nor.the-rn.info/*` on `the-rn.info`. Future deploys will keep the binding in place.
- `README.md`: mention the route binding in the Deploy section.
- `CLAUDE.md`: same, plus a note that the apex and `www` routes still belong to the legacy `northern-information-sentinel` Worker (out of scope for this Worker).

## Validation

`npx wrangler deploy --dry-run --outdir /tmp/wrangler-dryrun` parses the new config cleanly. Live traffic on `https://nor.the-rn.info/rm_ation/` is unaffected because the route already exists pointing at the same script — the next real deploy will be idempotent.