### PR TITLE
Fold sentinel canonicalization into main Worker

### DIFF
--- a/worker/index.js
+++ b/worker/index.js
@@ -1,8 +1,25 @@
 const PREFIX = '/rm_ation'
+const CANONICAL_HOST = 'nor.the-rn.info'
+
+// Hostnames that 301-redirect to the canonical site (with the prefix).
+// Folded in from northern-information-sentinel and etters-co-sentinel.
+const ALIAS_HOSTS = new Set([
+  'the-rn.info',
+  'www.the-rn.info',
+  'etters.co',
+  'www.etters.co',
+])
 
 export default {
   async fetch(request, env) {
     const url = new URL(request.url)
+
+    if (ALIAS_HOSTS.has(url.hostname)) {
+      const target = new URL(request.url)
+      target.hostname = CANONICAL_HOST
+      target.pathname = `${PREFIX}${url.pathname}`
+      return Response.redirect(target.toString(), 301)
+    }
 
     if (url.pathname === PREFIX || url.pathname.startsWith(`${PREFIX}/`)) {
       url.pathname = url.pathname.slice(PREFIX.length) || '/'


### PR DESCRIPTION
- Move the apex/www → nor.the-rn.info/rm_ation/* redirect logic from \`northern-information-sentinel\` (and the etters.co equivalent from \`etters-co-sentinel\`) into the main Worker.
- Worker now handles four extra aliases at the top of \`fetch()\`: \`the-rn.info\`, \`www.the-rn.info\`, \`etters.co\`, \`www.etters.co\` — all 301 to \`https://nor.the-rn.info/rm_ation/<path>\`.
- Routes are not added to \`wrangler.jsonc\` in this PR. Sequence: merge → deploy → API-swap the four sentinel-owned routes onto this Worker → verify → delete sentinels → follow-up PR adds the routes to \`wrangler.jsonc\` for source-control.
- etters.co behavior collapses from two redirect hops (etters.co → nor.the-rn.info/ → /rm_ation/) to one (etters.co → nor.the-rn.info/rm_ation/<path>), preserving path.