### PR TITLE
Source-control alias hostnames in wrangler.jsonc routes

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,6 +17,22 @@
     {
       "pattern": "nor.the-rn.info/*",
       "zone_name": "the-rn.info"
+    },
+    {
+      "pattern": "the-rn.info/*",
+      "zone_name": "the-rn.info"
+    },
+    {
+      "pattern": "www.the-rn.info/*",
+      "zone_name": "the-rn.info"
+    },
+    {
+      "pattern": "etters.co/*",
+      "zone_name": "etters.co"
+    },
+    {
+      "pattern": "www.etters.co/*",
+      "zone_name": "etters.co"
     }
   ]
 }


### PR DESCRIPTION
After sentinel consolidation (PR #7), the four alias-host routes were repointed at this Worker via API. Declaring them in wrangler.jsonc so future deploys reaffirm the bindings instead of leaving them as dashboard-only state.