### PR TITLE
Drop etters.co routes from wrangler.jsonc (token scope)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -25,14 +25,6 @@
     {
       "pattern": "www.the-rn.info/*",
       "zone_name": "the-rn.info"
-    },
-    {
-      "pattern": "etters.co/*",
-      "zone_name": "etters.co"
-    },
-    {
-      "pattern": "www.etters.co/*",
-      "zone_name": "etters.co"
     }
   ]
 }


### PR DESCRIPTION
PR #8 attempted to source-control these but the deploy token lacks etters.co zone scope. Routes still bound to this Worker via API — just not declared here.