### PR TITLE
Remove etters.co handling + bump action versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.12.0
           cache: npm
@@ -25,7 +25,7 @@ jobs:
 
       - run: npm run build
 
-      - uses: cloudflare/wrangler-action@v3
+      - uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           command: deploy

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,14 +1,9 @@
 const PREFIX = '/rm_ation'
 const CANONICAL_HOST = 'nor.the-rn.info'
 
-// Hostnames that 301-redirect to the canonical site (with the prefix).
-// Folded in from northern-information-sentinel and etters-co-sentinel.
-const ALIAS_HOSTS = new Set([
-  'the-rn.info',
-  'www.the-rn.info',
-  'etters.co',
-  'www.etters.co',
-])
+// Apex and www of the-rn.info redirect to the canonical site (with the prefix).
+// etters.co has its own dedicated Worker (tyleretters/etters.co).
+const ALIAS_HOSTS = new Set(['the-rn.info', 'www.the-rn.info'])
 
 export default {
   async fetch(request, env) {


### PR DESCRIPTION
etters.co moved to dedicated Worker (tyleretters/etters.co). Action versions bumped to Node 24-compatible: checkout@v6, setup-node@v6, wrangler-action@v4.