### PR TITLE
Migrate asset URLs from AWS S3 + CloudFront to Cloudflare R2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@11ty/eleventy": "3.1.5",
         "@11ty/eleventy-img": "6.0.4",
         "@tailwindcss/cli": "4.3.0",
-        "@tyleretters/discography": "3.0.4",
+        "@tyleretters/discography": "3.0.5",
         "concurrently": "9.2.1",
         "luxon": "3.7.2",
         "markdown-it": "14.1.1",
@@ -2173,9 +2173,9 @@
       }
     },
     "node_modules/@tyleretters/discography": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@tyleretters/discography/-/discography-3.0.4.tgz",
-      "integrity": "sha512-k0UIXuOxShKXYs1MQrO9m/fmf4MDie2RHMpBYbLWbConJ1toLHXmQEkAbTKIR+8LrGg/ltFAYojkrPYIWgxbpw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@tyleretters/discography/-/discography-3.0.5.tgz",
+      "integrity": "sha512-g806msiWMw3AlsHiwQ943C5rWaKYOvLNE8rdmx6UrpY0vTSvoGJeX1cayTFwYVsy1zYR+NZaxUDA6N74FBhC1w==",
       "dev": true,
       "license": "CC-BY-SA-4.0",
       "engines": {
@@ -4497,7 +4497,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4521,7 +4520,6 @@
       "integrity": "sha512-7Hc+IvlQ7hlaIfQFZnxlRl0jnpWq2qwibORBhQYIb0QbNtuicc5ZxvKkVT71HJ4Py1wSZ/3VR1r8LfkCtoCzhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "posthtml-parser": "^0.11.0",
         "posthtml-render": "^3.0.0"
@@ -4575,7 +4573,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5094,7 +5091,6 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -5123,7 +5119,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@11ty/eleventy": "3.1.5",
     "@11ty/eleventy-img": "6.0.4",
     "@tailwindcss/cli": "4.3.0",
-    "@tyleretters/discography": "3.0.4",
+    "@tyleretters/discography": "3.0.5",
     "concurrently": "9.2.1",
     "luxon": "3.7.2",
     "markdown-it": "14.1.1",

--- a/src/data/resources.js
+++ b/src/data/resources.js
@@ -1,33 +1,33 @@
 export default [
   {
-    url: 'https://dop82cmkdnrqr.cloudfront.net/mixtape.svg',
+    url: 'https://dl.the-rn.info/mixtape.svg',
     size: '2KB',
     title: 'Mixtape Logo (SVG)',
     description: 'Inspired by both the MiniDisc and MIDI logos.',
   },
   {
-    url: 'https://dop82cmkdnrqr.cloudfront.net/the-gateway-experience.zip',
+    url: 'https://dl.the-rn.info/the-gateway-experience.zip',
     size: '11.19GB',
     title: 'The Gateway Experience',
     description:
       'I am more than my physical body. Because I am more than physical matter, I deeply desire to Expand, to Experience; to Know, to Understand; to Control, to Use such greater energies and energy systems as may be beneficial and constructive to me and to those near and close to me. Also, I deeply desire the help and cooperation, the assistance, the understanding of those individuals whose wisdom, development, and experience are equal or greater than my own.',
   },
   {
-    url: 'https://dop82cmkdnrqr.cloudfront.net/commonweal-textures.zip',
+    url: 'https://dl.the-rn.info/commonweal-textures.zip',
     size: '1.18GB',
     title: 'Commonweal Textures',
     description:
       'Original digital photography from the Commonweal site in Bolinas, CA. Formerly an "over the horizon radar" station built circa 1914. There are frequent reports of paranormal activity in this and surrounding zones. Location and metadata is intact.',
   },
   {
-    url: 'https://dop82cmkdnrqr.cloudfront.net/mkii-factory.zip',
+    url: 'https://dl.the-rn.info/mkii-factory.zip',
     size: '5.1GB',
     title: 'Octatrack MKII Factory Sample Pack',
     description:
       'Anniversary Edition: Chains, Claps, Congas, Cymbals Hats, Journal Kicks, Loops, Noise, Other, Rides, Rims, Snares, Synths, Tambs, & Toms.',
   },
   {
-    url: 'https://dop82cmkdnrqr.cloudfront.net/the-phantom-mk-racks.zip',
+    url: 'https://dl.the-rn.info/the-phantom-mk-racks.zip',
     size: '26KB',
     title: 'the phantom mk racks',
     description:

--- a/src/data/subsidiaries.js
+++ b/src/data/subsidiaries.js
@@ -91,7 +91,7 @@ export default [
     image: '/images/cascade.png',
     content: `Cascade is a M4L sequencer that holds every combination of eighth notes possible in a 4/4 bar. I wrote a [lengthly post about it on Highland's blog](https://journal.highlandsolutions.com/meet-cascade-a-piece-of-music-software-i-built-with-max-and-rapid-prototyping-d8ce9bda3a5b) and made [a short demo video](https://www.youtube.com/watch?v=VQhQaYClE78&feature=youtu.be).
 
-    [Download the patch, M4L Device, and demo.](https://s3.us-east-2.amazonaws.com/northerninformation/cascade.zip)`,
+    [Download the patch, M4L Device, and demo.](https://dl.the-rn.info/cascade.zip)`,
   },
   {
     title: 'Endless Field Studios',
@@ -105,7 +105,7 @@ export default [
     image: '/images/second-chance.jpg',
     content: `Explore the world of 'second chance' with your mouse and the WASD keys. Principal development occurred during a Unity workshop at [gli.tc/h 2112](http://gli.tc/h/2112/). Don't fall.
 
-    [Download for macOS.](https://s3.us-east-2.amazonaws.com/northerninformation/second-chance.app.zip)`,
+    [Download for macOS.](https://dl.the-rn.info/second-chance.app.zip)`,
   },
   {
     title: 'Epicycle',

--- a/src/pages/video.md
+++ b/src/pages/video.md
@@ -1,7 +1,7 @@
 ---
 title: Video
 layout: video.njk
-videoSrc: "https://d107e1o0dn11sc.cloudfront.net/dj-stuxnet/kowloon-walled-city-giga-mix/mobile-kowloon-city-leyline.mp4"
+videoSrc: "https://assets.the-rn.info/dj-stuxnet/kowloon-walled-city-giga-mix/mobile-kowloon-city-leyline.mp4"
 videos:
   - id: eZtNgGEeGo4
     title: "fc211016_09 //// Sidereal Lobby (2021)"

--- a/src/posts/2006-01-01-files.md
+++ b/src/posts/2006-01-01-files.md
@@ -3,7 +3,7 @@ title: "Files"
 date: 2006-01-01
 ---
 
-![Files](https://d107e1o0dn11sc.cloudfront.net/lucid-end/files/files.jpg)
+![Files](https://assets.the-rn.info/lucid-end/files/files.jpg)
 
 **LP** by **[Lucid End](/project/lucid-end/)**
 Independent · CD-R

--- a/src/posts/2006-01-01-ix-ep.md
+++ b/src/posts/2006-01-01-ix-ep.md
@@ -3,7 +3,7 @@ title: "Ix E.P."
 date: 2006-01-01
 ---
 
-![Ix E.P.](https://d107e1o0dn11sc.cloudfront.net/ix/ix-ep/ix-ep.jpg)
+![Ix E.P.](https://assets.the-rn.info/ix/ix-ep/ix-ep.jpg)
 
 **EP** by **[Ix](/project/ix/)**
 Independent · CD-R

--- a/src/posts/2006-01-01-yet-these-memories-isolated-us.md
+++ b/src/posts/2006-01-01-yet-these-memories-isolated-us.md
@@ -3,7 +3,7 @@ title: "Yet These Memories Isolated Us"
 date: 2006-01-01
 ---
 
-![Yet These Memories Isolated Us](https://d107e1o0dn11sc.cloudfront.net/ix/yet-these-memories-isolated-us/yet-these-memories-isolated-us.jpg)
+![Yet These Memories Isolated Us](https://assets.the-rn.info/ix/yet-these-memories-isolated-us/yet-these-memories-isolated-us.jpg)
 
 **Single** by **[Ix](/project/ix/)**
 Endless Field Studios · CD-R

--- a/src/posts/2007-01-01-organica-lensing.md
+++ b/src/posts/2007-01-01-organica-lensing.md
@@ -3,7 +3,7 @@ title: "Organica Lensing"
 date: 2007-01-01
 ---
 
-![Organica Lensing](https://d107e1o0dn11sc.cloudfront.net/lucid-end/organica-lensing/organica-lensing.jpg)
+![Organica Lensing](https://assets.the-rn.info/lucid-end/organica-lensing/organica-lensing.jpg)
 
 **Single** by **[Lucid End](/project/lucid-end/)**
 Independent · CD

--- a/src/posts/2007-01-01-the-killing-tree.md
+++ b/src/posts/2007-01-01-the-killing-tree.md
@@ -3,7 +3,7 @@ title: "The Killing Tree"
 date: 2007-01-01
 ---
 
-![The Killing Tree](https://d107e1o0dn11sc.cloudfront.net/lucid-end/the-killing-tree/the-killing-tree.jpg)
+![The Killing Tree](https://assets.the-rn.info/lucid-end/the-killing-tree/the-killing-tree.jpg)
 
 **Single** by **[Lucid End](/project/lucid-end/)**
 Independent · CD-R

--- a/src/posts/2007-01-01-time-to-breathe-time-to-think.md
+++ b/src/posts/2007-01-01-time-to-breathe-time-to-think.md
@@ -3,7 +3,7 @@ title: "Time to Breathe; Time to Think"
 date: 2007-01-01
 ---
 
-![Time to Breathe; Time to Think](https://d107e1o0dn11sc.cloudfront.net/lucid-end/time-to-breathe-time-to-think/time-to-breathe-time-to-think.jpg)
+![Time to Breathe; Time to Think](https://assets.the-rn.info/lucid-end/time-to-breathe-time-to-think/time-to-breathe-time-to-think.jpg)
 
 **LP** by **[Lucid End](/project/lucid-end/)**
 Independent · CD-R

--- a/src/posts/2007-04-08-descent-into-dreams.md
+++ b/src/posts/2007-04-08-descent-into-dreams.md
@@ -3,7 +3,7 @@ title: "Descent Into Dreams"
 date: 2007-04-08
 ---
 
-![Descent Into Dreams](https://d107e1o0dn11sc.cloudfront.net/ix/descent-into-dreams/descent-into-dreams.jpg)
+![Descent Into Dreams](https://assets.the-rn.info/ix/descent-into-dreams/descent-into-dreams.jpg)
 
 **LP** by **[Ix](/project/ix/)**
 Endless Field Studios · CD

--- a/src/posts/2008-01-01-suntelia-aeon.md
+++ b/src/posts/2008-01-01-suntelia-aeon.md
@@ -3,7 +3,7 @@ title: "Suntelia Aeon"
 date: 2008-01-01
 ---
 
-![Suntelia Aeon](https://d107e1o0dn11sc.cloudfront.net/inocula/suntelia-aeon/suntelia-aeon.jpg)
+![Suntelia Aeon](https://assets.the-rn.info/inocula/suntelia-aeon/suntelia-aeon.jpg)
 
 **LP** by **[Inocula](/project/inocula/)**
 Karma Productions · CD, Digital

--- a/src/posts/2008-11-11-gates-ep.md
+++ b/src/posts/2008-11-11-gates-ep.md
@@ -3,7 +3,7 @@ title: "Gates E.P."
 date: 2008-11-11
 ---
 
-![Gates E.P.](https://d107e1o0dn11sc.cloudfront.net/everything-comes-in-cycles-everything-fades-in-shades/gates-ep/gates-ep.jpg)
+![Gates E.P.](https://assets.the-rn.info/everything-comes-in-cycles-everything-fades-in-shades/gates-ep/gates-ep.jpg)
 
 **EP** by **[Everything Comes in Cycles; Everything Fades in Shades](/project/everything-comes-in-cycles-everything-fades-in-shades/)**
 Endless Field Studios · CD, Digital

--- a/src/posts/2009-09-01-as-quippolous-codes-quietly-count.md
+++ b/src/posts/2009-09-01-as-quippolous-codes-quietly-count.md
@@ -3,7 +3,7 @@ title: "As Quippolous Codes Quietly Count"
 date: 2009-09-01
 ---
 
-![As Quippolous Codes Quietly Count](https://d107e1o0dn11sc.cloudfront.net/connectedness-locus/as-quippolous-codes-quietly-count/as-quippolous-codes-quietly-count.jpg)
+![As Quippolous Codes Quietly Count](https://assets.the-rn.info/connectedness-locus/as-quippolous-codes-quietly-count/as-quippolous-codes-quietly-count.jpg)
 
 **LP** by **[Connectedness Locus](/project/connectedness-locus/)**
 Endless Field Studios · CD, Digital

--- a/src/posts/2009-09-01-serial-index-of-unclaimed-memories-file-1.md
+++ b/src/posts/2009-09-01-serial-index-of-unclaimed-memories-file-1.md
@@ -3,7 +3,7 @@ title: "Serial Index of Unclaimed Memories, File 1"
 date: 2009-09-01
 ---
 
-![Serial Index of Unclaimed Memories, File 1](https://d107e1o0dn11sc.cloudfront.net/everything-comes-in-cycles-everything-fades-in-shades/serial-index-of-unclaimed-memories-file-1/serial-index-of-unclaimed-memories-file-1.jpg)
+![Serial Index of Unclaimed Memories, File 1](https://assets.the-rn.info/everything-comes-in-cycles-everything-fades-in-shades/serial-index-of-unclaimed-memories-file-1/serial-index-of-unclaimed-memories-file-1.jpg)
 
 **LP** by **[Everything Comes in Cycles; Everything Fades in Shades](/project/everything-comes-in-cycles-everything-fades-in-shades/)**
 Endless Field Studios · Digital

--- a/src/posts/2009-09-01-serial-index-of-unclaimed-memories-file-2.md
+++ b/src/posts/2009-09-01-serial-index-of-unclaimed-memories-file-2.md
@@ -3,7 +3,7 @@ title: "Serial Index of Unclaimed Memories, File 2"
 date: 2009-09-01
 ---
 
-![Serial Index of Unclaimed Memories, File 2](https://d107e1o0dn11sc.cloudfront.net/everything-comes-in-cycles-everything-fades-in-shades/serial-index-of-unclaimed-memories-file-2/serial-index-of-unclaimed-memories-file-2.jpg)
+![Serial Index of Unclaimed Memories, File 2](https://assets.the-rn.info/everything-comes-in-cycles-everything-fades-in-shades/serial-index-of-unclaimed-memories-file-2/serial-index-of-unclaimed-memories-file-2.jpg)
 
 **LP** by **[Everything Comes in Cycles; Everything Fades in Shades](/project/everything-comes-in-cycles-everything-fades-in-shades/)**
 Endless Field Studios · Digital

--- a/src/posts/2010-02-18-when-the-paint-peels.md
+++ b/src/posts/2010-02-18-when-the-paint-peels.md
@@ -3,7 +3,7 @@ title: "When the Paint Peels"
 date: 2010-02-18
 ---
 
-![When the Paint Peels](https://d107e1o0dn11sc.cloudfront.net/connectedness-locus/when-the-paint-peels/when-the-paint-peels.jpg)
+![When the Paint Peels](https://assets.the-rn.info/connectedness-locus/when-the-paint-peels/when-the-paint-peels.jpg)
 
 **Single** by **[Connectedness Locus](/project/connectedness-locus/)**
 Endless Field Studios · Digital

--- a/src/posts/2011-07-30-terraforms.md
+++ b/src/posts/2011-07-30-terraforms.md
@@ -3,7 +3,7 @@ title: "Terraforms"
 date: 2011-07-30
 ---
 
-![Terraforms](https://d107e1o0dn11sc.cloudfront.net/connectedness-locus/terraforms/terraforms.jpg)
+![Terraforms](https://assets.the-rn.info/connectedness-locus/terraforms/terraforms.jpg)
 
 **LP** by **[Connectedness Locus](/project/connectedness-locus/)**
 Endless Field Studios · CD, Digital

--- a/src/posts/2012-10-15-prolegomenon.md
+++ b/src/posts/2012-10-15-prolegomenon.md
@@ -3,7 +3,7 @@ title: "Prolegomenon"
 date: 2012-10-15
 ---
 
-![Prolegomenon](https://d107e1o0dn11sc.cloudfront.net/connectedness-locus/prolegomenon/prolegomenon.jpg)
+![Prolegomenon](https://assets.the-rn.info/connectedness-locus/prolegomenon/prolegomenon.jpg)
 
 **EP** by **[Connectedness Locus](/project/connectedness-locus/)**
 Endless Field Studios · Digital

--- a/src/posts/2013-01-01-the-geometrie-of-our-lost-cause.md
+++ b/src/posts/2013-01-01-the-geometrie-of-our-lost-cause.md
@@ -3,7 +3,7 @@ title: "the geometrie of our lost cause"
 date: 2013-01-01
 ---
 
-![the geometrie of our lost cause](https://d107e1o0dn11sc.cloudfront.net/tyler-etters-and-the-northern-information-movement/the-geometrie-of-our-lost-cause/the-geometrie-of-our-lost-cause.jpg)
+![the geometrie of our lost cause](https://assets.the-rn.info/tyler-etters-and-the-northern-information-movement/the-geometrie-of-our-lost-cause/the-geometrie-of-our-lost-cause.jpg)
 
 **LP** by **[tyler etters & the northern information movement](/project/tyler-etters-and-the-northern-information-movement/)**
 Endless Field Studios · Cassette, Digital

--- a/src/posts/2013-06-21-blue-the-most-celestial-color.md
+++ b/src/posts/2013-06-21-blue-the-most-celestial-color.md
@@ -3,7 +3,7 @@ title: "blue, the most celestial color"
 date: 2013-06-21
 ---
 
-![blue, the most celestial color](https://d107e1o0dn11sc.cloudfront.net/tyler-etters-and-the-northern-information-movement/blue-the-most-celestial-color/blue-the-most-celestial-color.jpg)
+![blue, the most celestial color](https://assets.the-rn.info/tyler-etters-and-the-northern-information-movement/blue-the-most-celestial-color/blue-the-most-celestial-color.jpg)
 
 **LP** by **[tyler etters & the northern information movement](/project/tyler-etters-and-the-northern-information-movement/)**
 Endless Field Studios · Digital

--- a/src/posts/2013-09-23-senescence.md
+++ b/src/posts/2013-09-23-senescence.md
@@ -3,7 +3,7 @@ title: "senescence"
 date: 2013-09-23
 ---
 
-![senescence](https://d107e1o0dn11sc.cloudfront.net/tyler-etters-and-the-northern-information-movement/senescence/senescence.jpg)
+![senescence](https://assets.the-rn.info/tyler-etters-and-the-northern-information-movement/senescence/senescence.jpg)
 
 **LP** by **[tyler etters & the northern information movement](/project/tyler-etters-and-the-northern-information-movement/)**
 Endless Field Studios · Digital

--- a/src/posts/2014-07-28-generative.md
+++ b/src/posts/2014-07-28-generative.md
@@ -5,4 +5,4 @@ date: 2014-07-28
 
 ![generative](/images/generative.gif)
 
-Sometimes you just have to give up. The intention of releasing a unique 'generative' track with each of the hundred cassette purchases has been cast into the wind. Twenty-five hours of generative music is good. Infinity hours of generative music is better. Download the [live master file](https://s3.us-east-2.amazonaws.com/northerninformation/generative.zip) and play the first scene. The #shadow_fi Trilogy is over. The #shadow_fi Trilogy is endless.
+Sometimes you just have to give up. The intention of releasing a unique 'generative' track with each of the hundred cassette purchases has been cast into the wind. Twenty-five hours of generative music is good. Infinity hours of generative music is better. Download the [live master file](https://dl.the-rn.info/generative.zip) and play the first scene. The #shadow_fi Trilogy is over. The #shadow_fi Trilogy is endless.

--- a/src/posts/2015-01-01-the-phantoms-of-our-lost-cause.md
+++ b/src/posts/2015-01-01-the-phantoms-of-our-lost-cause.md
@@ -3,7 +3,7 @@ title: "the phantoms of our lost cause"
 date: 2015-01-01
 ---
 
-![the phantoms of our lost cause](https://d107e1o0dn11sc.cloudfront.net/tyler-etters-and-the-northern-information-movement/the-phantoms-of-our-lost-cause/the-phantoms-of-our-lost-cause.jpg)
+![the phantoms of our lost cause](https://assets.the-rn.info/tyler-etters-and-the-northern-information-movement/the-phantoms-of-our-lost-cause/the-phantoms-of-our-lost-cause.jpg)
 
 **LP** by **[tyler etters & the northern information movement](/project/tyler-etters-and-the-northern-information-movement/)**
 Endless Field Studios · Digital

--- a/src/posts/2015-03-29-zulu.md
+++ b/src/posts/2015-03-29-zulu.md
@@ -3,7 +3,7 @@ title: "zulu"
 date: 2015-03-29
 ---
 
-![zulu](https://d107e1o0dn11sc.cloudfront.net/tyler-etters-and-the-northern-information-movement/zulu/zulu.jpg)
+![zulu](https://assets.the-rn.info/tyler-etters-and-the-northern-information-movement/zulu/zulu.jpg)
 
 **LP** by **[tyler etters & the northern information movement](/project/tyler-etters-and-the-northern-information-movement/)**
 Endless Field Studios · Digital

--- a/src/posts/2015-04-05-second-chance.md
+++ b/src/posts/2015-04-05-second-chance.md
@@ -7,6 +7,6 @@ date: 2015-04-05
 
 Explore the world of 'second chance' with your mouse and the WASD keys. Principal development occurred during a Unity workshop at [gli.tc/h 2112](http://gli.tc/h/2112/). Don't fall.
 
-[Download for macOS](https://s3.us-east-2.amazonaws.com/northerninformation/second-chance.app.zip)
+[Download for macOS](https://dl.the-rn.info/second-chance.app.zip)
 
 `md5: 4f67f4888f3da39911b4e992f78b7d5b`

--- a/src/posts/2015-06-21-and-though-the-soft-apocalypse-may-yet-overtake.md
+++ b/src/posts/2015-06-21-and-though-the-soft-apocalypse-may-yet-overtake.md
@@ -3,7 +3,7 @@ title: "and though the soft apocalypse may yet overtake"
 date: 2015-06-21
 ---
 
-![and though the soft apocalypse may yet overtake](https://d107e1o0dn11sc.cloudfront.net/tyler-etters-and-the-northern-information-movement/and-though-the-soft-apocalypse-may-yet-overtake/and-though-the-soft-apocalypse-may-yet-overtake.jpg)
+![and though the soft apocalypse may yet overtake](https://assets.the-rn.info/tyler-etters-and-the-northern-information-movement/and-though-the-soft-apocalypse-may-yet-overtake/and-though-the-soft-apocalypse-may-yet-overtake.jpg)
 
 **LP** by **[tyler etters & the northern information movement](/project/tyler-etters-and-the-northern-information-movement/)**
 Endless Field Studios · Digital

--- a/src/posts/2017-01-17-the-legacy-of-our-lost-cause.md
+++ b/src/posts/2017-01-17-the-legacy-of-our-lost-cause.md
@@ -3,7 +3,7 @@ title: "the legacy of our lost cause"
 date: 2017-01-17
 ---
 
-![the legacy of our lost cause](https://d107e1o0dn11sc.cloudfront.net/tyler-etters-and-the-northern-information-movement/the-legacy-of-our-lost-cause/the-legacy-of-our-lost-cause.jpg)
+![the legacy of our lost cause](https://assets.the-rn.info/tyler-etters-and-the-northern-information-movement/the-legacy-of-our-lost-cause/the-legacy-of-our-lost-cause.jpg)
 
 **LP** by **[tyler etters & the northern information movement](/project/tyler-etters-and-the-northern-information-movement/)**
 Endless Field Studios · Digital

--- a/src/posts/2017-12-21-dispatches-from-the-prime-meridian.md
+++ b/src/posts/2017-12-21-dispatches-from-the-prime-meridian.md
@@ -3,7 +3,7 @@ title: "dispatches from the prime meridian"
 date: 2017-12-21
 ---
 
-![dispatches from the prime meridian](https://d107e1o0dn11sc.cloudfront.net/tyler-etters-and-the-northern-information-movement/dispatches-from-the-prime-meridian/dispatches-from-the-prime-meridian.jpg)
+![dispatches from the prime meridian](https://assets.the-rn.info/tyler-etters-and-the-northern-information-movement/dispatches-from-the-prime-meridian/dispatches-from-the-prime-meridian.jpg)
 
 **LP** by **[tyler etters & the northern information movement](/project/tyler-etters-and-the-northern-information-movement/)**
 Endless Field Studios · Digital

--- a/src/posts/2017-12-22-reverence.md
+++ b/src/posts/2017-12-22-reverence.md
@@ -3,7 +3,7 @@ title: "reverence"
 date: 2017-12-22
 ---
 
-![reverence](https://d107e1o0dn11sc.cloudfront.net/tyler-etters-and-the-northern-information-movement/reverence/reverence.jpg)
+![reverence](https://assets.the-rn.info/tyler-etters-and-the-northern-information-movement/reverence/reverence.jpg)
 
 **LP** by **[tyler etters & the northern information movement](/project/tyler-etters-and-the-northern-information-movement/)**
 Endless Field Studios · Digital

--- a/src/posts/2018-10-31-synergy-beat-music-volume-1.md
+++ b/src/posts/2018-10-31-synergy-beat-music-volume-1.md
@@ -3,7 +3,7 @@ title: "Synergy Beat Music, Volume 1"
 date: 2018-10-31
 ---
 
-![Synergy Beat Music, Volume 1](https://d107e1o0dn11sc.cloudfront.net/synergy-beat/synergy-beat-music-volume-1/synergy-beat-music-volume-1.jpg)
+![Synergy Beat Music, Volume 1](https://assets.the-rn.info/synergy-beat/synergy-beat-music-volume-1/synergy-beat-music-volume-1.jpg)
 
 **Compilation** by **[Synergy Beat](/project/synergy-beat/)**
 Synergy Beat · Digital

--- a/src/posts/2019-03-03-ep1.md
+++ b/src/posts/2019-03-03-ep1.md
@@ -3,7 +3,7 @@ title: "EP1"
 date: 2019-03-03
 ---
 
-![EP1](https://d107e1o0dn11sc.cloudfront.net/they-became-what-they-beheld/ep1/ep1.jpg)
+![EP1](https://assets.the-rn.info/they-became-what-they-beheld/ep1/ep1.jpg)
 
 **EP** by **[They Became What They Beheld](/project/they-became-what-they-beheld/)**
 Intertext · Digital

--- a/src/posts/2019-08-04-i-dream-of-artificial-crickets-and-weather-data.md
+++ b/src/posts/2019-08-04-i-dream-of-artificial-crickets-and-weather-data.md
@@ -13,4 +13,4 @@ The program allows you to select a weather station. It then grabs the temperatur
 
 I love the idea of remotely experiencing temperature via something other than a number (i.e. 72°) or color (i.e. red). There is also something I can't quite put my finger on... Perhaps related to simulating crickets in places where they shouldn't be? And during seasons when they might normally be dormant?
 
-[Download the Max patch here.](https://dop82cmkdnrqr.cloudfront.net/crickets.zip)
+[Download the Max patch here.](https://dl.the-rn.info/crickets.zip)

--- a/src/posts/2020-06-17-my-third-patch.md
+++ b/src/posts/2020-06-17-my-third-patch.md
@@ -5,7 +5,7 @@ date: 2020-06-17
 
 ![My third patch](/images/my-third-patch.jpg)
 
-<audio controls crossorigin="anonymous" src="https://dop82cmkdnrqr.cloudfront.net/blog/my-third-patch.mp3"></audio>
+<audio controls crossorigin="anonymous" src="https://dl.the-rn.info/blog/my-third-patch.mp3"></audio>
 
 Drones I wanted, and drones I created.
 

--- a/src/posts/2020-07-12-amb-7.md
+++ b/src/posts/2020-07-12-amb-7.md
@@ -5,4 +5,4 @@ date: 2020-07-12
 
 ![amb_7](/images/amb_7.jpg)
 
-<audio controls crossorigin="anonymous" src="https://dop82cmkdnrqr.cloudfront.net/blog/amb_7.mp3"></audio>
+<audio controls crossorigin="anonymous" src="https://dl.the-rn.info/blog/amb_7.mp3"></audio>

--- a/src/posts/2020-12-13-the-arecibo-lamentations.md
+++ b/src/posts/2020-12-13-the-arecibo-lamentations.md
@@ -3,7 +3,7 @@ title: "The Arecibo Lamentations"
 date: 2020-12-13
 ---
 
-![The Arecibo Lamentations](https://d107e1o0dn11sc.cloudfront.net/northern-information/the-arecibo-lamentations/the-arecibo-lamentations.jpg)
+![The Arecibo Lamentations](https://assets.the-rn.info/northern-information/the-arecibo-lamentations/the-arecibo-lamentations.jpg)
 
 **LP** by **[Northern Information](/project/northern-information/)**
 Intertext · Digital

--- a/src/posts/2021-03-14-carrier-demo.md
+++ b/src/posts/2021-03-14-carrier-demo.md
@@ -3,7 +3,7 @@ title: "CARRIER (demo)"
 date: 2021-03-14
 ---
 
-![CARRIER (demo)](https://d107e1o0dn11sc.cloudfront.net/stuxnet/carrier-demo/carrier-demo.jpg)
+![CARRIER (demo)](https://assets.the-rn.info/stuxnet/carrier-demo/carrier-demo.jpg)
 
 **Demo** by **[STUXNET](/project/stuxnet/)**
 Intertext · Digital

--- a/src/posts/2021-03-28-cipher-suite-demo.md
+++ b/src/posts/2021-03-28-cipher-suite-demo.md
@@ -3,7 +3,7 @@ title: "CIPHER SUITE (demo)"
 date: 2021-03-28
 ---
 
-![CIPHER SUITE (demo)](https://d107e1o0dn11sc.cloudfront.net/stuxnet/cipher-suite-demo/cipher-suite-demo.jpg)
+![CIPHER SUITE (demo)](https://assets.the-rn.info/stuxnet/cipher-suite-demo/cipher-suite-demo.jpg)
 
 **Demo** by **[STUXNET](/project/stuxnet/)**
 Intertext · Digital

--- a/src/posts/2021-04-10-matryoshka-demo.md
+++ b/src/posts/2021-04-10-matryoshka-demo.md
@@ -3,7 +3,7 @@ title: "MATRYOSHKA (demo)"
 date: 2021-04-10
 ---
 
-![MATRYOSHKA (demo)](https://d107e1o0dn11sc.cloudfront.net/stuxnet/matryoshka-demo/matryoshka-demo.jpg)
+![MATRYOSHKA (demo)](https://assets.the-rn.info/stuxnet/matryoshka-demo/matryoshka-demo.jpg)
 
 **Demo** by **[STUXNET](/project/stuxnet/)**
 Intertext · Digital

--- a/src/posts/2021-04-18-times-firewall-demo.md
+++ b/src/posts/2021-04-18-times-firewall-demo.md
@@ -3,7 +3,7 @@ title: "TIME'S FIREWALL (demo)"
 date: 2021-04-18
 ---
 
-![TIME'S FIREWALL (demo)](https://d107e1o0dn11sc.cloudfront.net/stuxnet/times-firewall-demo/times-firewall-demo.jpg)
+![TIME'S FIREWALL (demo)](https://assets.the-rn.info/stuxnet/times-firewall-demo/times-firewall-demo.jpg)
 
 **Demo** by **[STUXNET](/project/stuxnet/)**
 Intertext · Digital

--- a/src/posts/2021-05-01-long-live-the-lost-ones.md
+++ b/src/posts/2021-05-01-long-live-the-lost-ones.md
@@ -3,7 +3,7 @@ title: "LONG LIVE THE LOST ONES"
 date: 2021-05-01
 ---
 
-![LONG LIVE THE LOST ONES](https://d107e1o0dn11sc.cloudfront.net/stuxnet/long-live-the-lost-ones/long-live-the-lost-ones.jpg)
+![LONG LIVE THE LOST ONES](https://assets.the-rn.info/stuxnet/long-live-the-lost-ones/long-live-the-lost-ones.jpg)
 
 **LP** by **[STUXNET](/project/stuxnet/)**
 Intertext · Digital

--- a/src/posts/2021-07-07-countersurveillance.md
+++ b/src/posts/2021-07-07-countersurveillance.md
@@ -3,7 +3,7 @@ title: "COUNTERSURVEILLANCE"
 date: 2021-07-07
 ---
 
-![COUNTERSURVEILLANCE](https://d107e1o0dn11sc.cloudfront.net/stuxnet/countersurveillance/countersurveillance.jpg)
+![COUNTERSURVEILLANCE](https://assets.the-rn.info/stuxnet/countersurveillance/countersurveillance.jpg)
 
 **EP** by **[STUXNET](/project/stuxnet/)**
 Intertext · Digital

--- a/src/posts/2021-07-26-human-interference-task-force.md
+++ b/src/posts/2021-07-26-human-interference-task-force.md
@@ -3,7 +3,7 @@ title: "HUMAN INTERFERENCE TASK FORCE"
 date: 2021-07-26
 ---
 
-![HUMAN INTERFERENCE TASK FORCE](https://d107e1o0dn11sc.cloudfront.net/stuxnet/human-interference-task-force/human-interference-task-force.jpg)
+![HUMAN INTERFERENCE TASK FORCE](https://assets.the-rn.info/stuxnet/human-interference-task-force/human-interference-task-force.jpg)
 
 **LP** by **[STUXNET](/project/stuxnet/)**
 Intertext · Digital

--- a/src/posts/2021-09-04-beaches.md
+++ b/src/posts/2021-09-04-beaches.md
@@ -3,7 +3,7 @@ title: "Beaches"
 date: 2021-09-04
 ---
 
-![Beaches](https://d107e1o0dn11sc.cloudfront.net/sidereal-lobby/beaches/beaches.jpg)
+![Beaches](https://assets.the-rn.info/sidereal-lobby/beaches/beaches.jpg)
 
 **Triple LP** by **[Sidereal Lobby](/project/sidereal-lobby/)**
 Map Corps · Digital

--- a/src/posts/2021-09-04-deep-state-music.md
+++ b/src/posts/2021-09-04-deep-state-music.md
@@ -3,7 +3,7 @@ title: "Deep State Music"
 date: 2021-09-04
 ---
 
-![Deep State Music](https://d107e1o0dn11sc.cloudfront.net/sidereal-lobby/deep-state-music/deep-state-music.jpg)
+![Deep State Music](https://assets.the-rn.info/sidereal-lobby/deep-state-music/deep-state-music.jpg)
 
 **Triple LP** by **[Sidereal Lobby](/project/sidereal-lobby/)**
 Map Corps · Digital

--- a/src/posts/2021-09-04-fciv.md
+++ b/src/posts/2021-09-04-fciv.md
@@ -3,7 +3,7 @@ title: "FCIV"
 date: 2021-09-04
 ---
 
-![FCIV](https://d107e1o0dn11sc.cloudfront.net/sidereal-lobby/fciv/fciv.jpg)
+![FCIV](https://assets.the-rn.info/sidereal-lobby/fciv/fciv.jpg)
 
 **Triple LP** by **[Sidereal Lobby](/project/sidereal-lobby/)**
 Map Corps · Digital

--- a/src/posts/2022-03-03-starscream.md
+++ b/src/posts/2022-03-03-starscream.md
@@ -3,4 +3,4 @@ title: "Starscream"
 date: 2022-03-03
 ---
 
-<audio controls crossorigin="anonymous" src="https://dop82cmkdnrqr.cloudfront.net/blog/starscream.mp3"></audio>
+<audio controls crossorigin="anonymous" src="https://dl.the-rn.info/blog/starscream.mp3"></audio>

--- a/src/posts/2022-03-12-ep2.md
+++ b/src/posts/2022-03-12-ep2.md
@@ -3,7 +3,7 @@ title: "EP2"
 date: 2022-03-12
 ---
 
-![EP2](https://d107e1o0dn11sc.cloudfront.net/they-became-what-they-beheld/ep2/ep2.jpg)
+![EP2](https://assets.the-rn.info/they-became-what-they-beheld/ep2/ep2.jpg)
 
 **EP** by **[They Became What They Beheld](/project/they-became-what-they-beheld/)**
 Intertext · Digital

--- a/src/posts/2023-03-20-fade-scatter-replicate.md
+++ b/src/posts/2023-03-20-fade-scatter-replicate.md
@@ -3,7 +3,7 @@ title: "FADE SCATTER REPLICATE"
 date: 2023-03-20
 ---
 
-![FADE SCATTER REPLICATE](https://d107e1o0dn11sc.cloudfront.net/stuxnet/fade-scatter-replicate/fade-scatter-replicate.jpg)
+![FADE SCATTER REPLICATE](https://assets.the-rn.info/stuxnet/fade-scatter-replicate/fade-scatter-replicate.jpg)
 
 **EP** by **[STUXNET](/project/stuxnet/)**
 Intertext · Digital

--- a/src/posts/2023-06-04-clip-2006-06-28-19-28-26.md
+++ b/src/posts/2023-06-04-clip-2006-06-28-19-28-26.md
@@ -5,7 +5,7 @@ date: 2023-06-04
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/zOjJlGdqWdI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
-raw: [https://dop82cmkdnrqr.cloudfront.net/blog/clip-2006-06-28+19%3B28%3B26.dv](https://dop82cmkdnrqr.cloudfront.net/blog/clip-2006-06-28+19%3B28%3B26.dv)
+raw: [https://dl.the-rn.info/blog/clip-2006-06-28+19%3B28%3B26.dv](https://dl.the-rn.info/blog/clip-2006-06-28+19%3B28%3B26.dv)
 
 memories of a very specific piece of .dv footage,\
 lingering in my mind for several years.\

--- a/src/posts/2023-12-22-in-darkness-radiant.md
+++ b/src/posts/2023-12-22-in-darkness-radiant.md
@@ -3,7 +3,7 @@ title: "IN DARKNESS RADIANT"
 date: 2023-12-22
 ---
 
-![IN DARKNESS RADIANT](https://d107e1o0dn11sc.cloudfront.net/stuxnet/in-darkness-radiant/in-darkness-radiant.jpg)
+![IN DARKNESS RADIANT](https://assets.the-rn.info/stuxnet/in-darkness-radiant/in-darkness-radiant.jpg)
 
 **EP** by **[STUXNET](/project/stuxnet/)**
 Intertext · Digital

--- a/src/posts/2024-04-14-ep3.md
+++ b/src/posts/2024-04-14-ep3.md
@@ -3,7 +3,7 @@ title: "EP3"
 date: 2024-04-14
 ---
 
-![EP3](https://d107e1o0dn11sc.cloudfront.net/they-became-what-they-beheld/ep3/ep3.jpg)
+![EP3](https://assets.the-rn.info/they-became-what-they-beheld/ep3/ep3.jpg)
 
 **EP** by **[They Became What They Beheld](/project/they-became-what-they-beheld/)**
 Intertext · Digital

--- a/src/posts/2024-04-22-respect-for-the-medium.md
+++ b/src/posts/2024-04-22-respect-for-the-medium.md
@@ -3,7 +3,7 @@ title: "Respect for the Medium"
 date: 2024-04-22
 ---
 
-![Respect for the Medium](https://d107e1o0dn11sc.cloudfront.net/they-became-what-they-beheld/respect-for-the-medium/respect-for-the-medium.jpg)
+![Respect for the Medium](https://assets.the-rn.info/they-became-what-they-beheld/respect-for-the-medium/respect-for-the-medium.jpg)
 
 **Single** by **[They Became What They Beheld](/project/they-became-what-they-beheld/)**
 Intertext · Digital

--- a/src/posts/2024-04-28-rocket-summer.md
+++ b/src/posts/2024-04-28-rocket-summer.md
@@ -3,7 +3,7 @@ title: "Rocket Summer"
 date: 2024-04-28
 ---
 
-![Rocket Summer](https://d107e1o0dn11sc.cloudfront.net/they-became-what-they-beheld/rocket-summer/rocket-summer.jpg)
+![Rocket Summer](https://assets.the-rn.info/they-became-what-they-beheld/rocket-summer/rocket-summer.jpg)
 
 **Single** by **[They Became What They Beheld](/project/they-became-what-they-beheld/)**
 Intertext · Digital

--- a/src/posts/2024-05-26-radio-free-albemuth.md
+++ b/src/posts/2024-05-26-radio-free-albemuth.md
@@ -3,7 +3,7 @@ title: "Radio Free Albemuth"
 date: 2024-05-26
 ---
 
-![Radio Free Albemuth](https://d107e1o0dn11sc.cloudfront.net/they-became-what-they-beheld/radio-free-albemuth/radio-free-albemuth.jpg)
+![Radio Free Albemuth](https://assets.the-rn.info/they-became-what-they-beheld/radio-free-albemuth/radio-free-albemuth.jpg)
 
 **LP** by **[They Became What They Beheld](/project/they-became-what-they-beheld/)**
 Intertext · Digital

--- a/src/posts/2024-06-16-distance.md
+++ b/src/posts/2024-06-16-distance.md
@@ -3,7 +3,7 @@ title: "Distance"
 date: 2024-06-16
 ---
 
-![Distance](https://d107e1o0dn11sc.cloudfront.net/they-became-what-they-beheld/distance/distance.jpg)
+![Distance](https://assets.the-rn.info/they-became-what-they-beheld/distance/distance.jpg)
 
 **Single** by **[They Became What They Beheld](/project/they-became-what-they-beheld/)**
 Intertext · Digital

--- a/src/posts/2024-07-10-list-of-stars-in-cancer.md
+++ b/src/posts/2024-07-10-list-of-stars-in-cancer.md
@@ -3,7 +3,7 @@ title: "List of Stars in Cancer"
 date: 2024-07-10
 ---
 
-![List of Stars in Cancer](https://d107e1o0dn11sc.cloudfront.net/they-became-what-they-beheld/list-of-stars-in-cancer/list-of-stars-in-cancer.jpg)
+![List of Stars in Cancer](https://assets.the-rn.info/they-became-what-they-beheld/list-of-stars-in-cancer/list-of-stars-in-cancer.jpg)
 
 **LP** by **[They Became What They Beheld](/project/they-became-what-they-beheld/)**
 Intertext · Digital

--- a/src/posts/2024-12-21-kowloon-walled-city-giga-mix.md
+++ b/src/posts/2024-12-21-kowloon-walled-city-giga-mix.md
@@ -3,7 +3,7 @@ title: "KOWLOON WALLED CITY GIGA MIX"
 date: 2024-12-21
 ---
 
-![KOWLOON WALLED CITY GIGA MIX](https://d107e1o0dn11sc.cloudfront.net/dj-stuxnet/kowloon-walled-city-giga-mix/kowloon-walled-city-giga-mix.jpg)
+![KOWLOON WALLED CITY GIGA MIX](https://assets.the-rn.info/dj-stuxnet/kowloon-walled-city-giga-mix/kowloon-walled-city-giga-mix.jpg)
 
 **Mix** by **[DJ STUXNET](/project/dj-stuxnet/)**
 Intertext · Digital

--- a/src/posts/2025-02-10-foxfires-kybalion.md
+++ b/src/posts/2025-02-10-foxfires-kybalion.md
@@ -3,7 +3,7 @@ title: "FOXFIRES / KYBALION"
 date: 2025-02-10
 ---
 
-![FOXFIRES / KYBALION](https://d107e1o0dn11sc.cloudfront.net/stuxnet/foxfires-kybalion/foxfires-kybalion.jpg)
+![FOXFIRES / KYBALION](https://assets.the-rn.info/stuxnet/foxfires-kybalion/foxfires-kybalion.jpg)
 
 **EP** by **[STUXNET](/project/stuxnet/)**
 Intertext · Digital

--- a/src/posts/2025-02-12-baysinski-event-ii-world-war-iii.md
+++ b/src/posts/2025-02-12-baysinski-event-ii-world-war-iii.md
@@ -3,7 +3,7 @@ title: "baysinski event ii world war iii"
 date: 2025-02-12
 ---
 
-![baysinski event ii world war iii](https://d107e1o0dn11sc.cloudfront.net/dj-stuxnet/baysinski-event-ii-world-war-iii/baysinski-event-ii-world-war-iii.jpg)
+![baysinski event ii world war iii](https://assets.the-rn.info/dj-stuxnet/baysinski-event-ii-world-war-iii/baysinski-event-ii-world-war-iii.jpg)
 
 **Mix** by **[DJ STUXNET](/project/dj-stuxnet/)**
 Intertext · Digital

--- a/src/posts/2025-03-23-elegies-for-ashley.md
+++ b/src/posts/2025-03-23-elegies-for-ashley.md
@@ -3,7 +3,7 @@ title: "ELEGIES FOR ASHLEY"
 date: 2025-03-23
 ---
 
-![ELEGIES FOR ASHLEY](https://d107e1o0dn11sc.cloudfront.net/dj-stuxnet/elegies-for-ashley/elegies-for-ashley.jpg)
+![ELEGIES FOR ASHLEY](https://assets.the-rn.info/dj-stuxnet/elegies-for-ashley/elegies-for-ashley.jpg)
 
 **Mix** by **[DJ STUXNET](/project/dj-stuxnet/)**
 Intertext · Digital

--- a/src/posts/2025-04-05-dissolution.md
+++ b/src/posts/2025-04-05-dissolution.md
@@ -3,7 +3,7 @@ title: "DISSOLUTION"
 date: 2025-04-05
 ---
 
-![DISSOLUTION](https://d107e1o0dn11sc.cloudfront.net/dj-stuxnet/dissolution/dissolution.jpg)
+![DISSOLUTION](https://assets.the-rn.info/dj-stuxnet/dissolution/dissolution.jpg)
 
 **Mix** by **[DJ STUXNET](/project/dj-stuxnet/)**
 Intertext · Digital

--- a/src/posts/2025-05-08-a-report-on-our-findings.md
+++ b/src/posts/2025-05-08-a-report-on-our-findings.md
@@ -3,7 +3,7 @@ title: "A report on our findings"
 date: 2025-05-08
 ---
 
-![A report on our findings](https://d107e1o0dn11sc.cloudfront.net/northern-information/a-report-on-our-findings/a-report-on-our-findings.jpg)
+![A report on our findings](https://assets.the-rn.info/northern-information/a-report-on-our-findings/a-report-on-our-findings.jpg)
 
 **LP** by **[Northern Information](/project/northern-information/)**
 Intertext · Digital

--- a/src/posts/2025-05-31-brooklyn-vengeance.md
+++ b/src/posts/2025-05-31-brooklyn-vengeance.md
@@ -3,7 +3,7 @@ title: "Brooklyn Vengeance"
 date: 2025-05-31
 ---
 
-![Brooklyn Vengeance](https://d107e1o0dn11sc.cloudfront.net/dj-stuxnet/brooklyn-vengeance/brooklyn-vengeance.jpg)
+![Brooklyn Vengeance](https://assets.the-rn.info/dj-stuxnet/brooklyn-vengeance/brooklyn-vengeance.jpg)
 
 **Mix** by **[DJ STUXNET](/project/dj-stuxnet/)**
 Intertext · Digital

--- a/src/posts/2025-06-14-midwest-sad-part-1.md
+++ b/src/posts/2025-06-14-midwest-sad-part-1.md
@@ -3,7 +3,7 @@ title: "midwest sad, part 1"
 date: 2025-06-14
 ---
 
-![midwest sad, part 1](https://d107e1o0dn11sc.cloudfront.net/dj-stuxnet/midwest-sad-part-1/midwest-sad-part-1.jpg)
+![midwest sad, part 1](https://assets.the-rn.info/dj-stuxnet/midwest-sad-part-1/midwest-sad-part-1.jpg)
 
 **Mix** by **[DJ STUXNET](/project/dj-stuxnet/)**
 Intertext · Digital

--- a/src/posts/2025-06-14-midwest-sad-part-2.md
+++ b/src/posts/2025-06-14-midwest-sad-part-2.md
@@ -3,7 +3,7 @@ title: "midwest sad, part 2"
 date: 2025-06-14
 ---
 
-![midwest sad, part 2](https://d107e1o0dn11sc.cloudfront.net/dj-stuxnet/midwest-sad-part-2/midwest-sad-part-2.jpg)
+![midwest sad, part 2](https://assets.the-rn.info/dj-stuxnet/midwest-sad-part-2/midwest-sad-part-2.jpg)
 
 **Mix** by **[DJ STUXNET](/project/dj-stuxnet/)**
 Intertext · Digital

--- a/src/posts/2025-06-21-psalms.md
+++ b/src/posts/2025-06-21-psalms.md
@@ -3,7 +3,7 @@ title: "Psalms"
 date: 2025-06-21
 ---
 
-![Psalms](https://d107e1o0dn11sc.cloudfront.net/dj-stuxnet/psalms/psalms.jpg)
+![Psalms](https://assets.the-rn.info/dj-stuxnet/psalms/psalms.jpg)
 
 **Mix** by **[DJ STUXNET](/project/dj-stuxnet/)**
 Intertext · Digital

--- a/src/posts/2025-06-21-the-vulgar-fractions-cold-wars-hyperstition.md
+++ b/src/posts/2025-06-21-the-vulgar-fractions-cold-wars-hyperstition.md
@@ -3,7 +3,7 @@ title: "THE VULGAR FRACTIONS: COLD WARS / HYPERSTITION"
 date: 2025-06-21
 ---
 
-![THE VULGAR FRACTIONS: COLD WARS / HYPERSTITION](https://d107e1o0dn11sc.cloudfront.net/stuxnet/the-vulgar-fractions-cold-wars-hyperstition/the-vulgar-fractions-cold-wars-hyperstition.jpg)
+![THE VULGAR FRACTIONS: COLD WARS / HYPERSTITION](https://assets.the-rn.info/stuxnet/the-vulgar-fractions-cold-wars-hyperstition/the-vulgar-fractions-cold-wars-hyperstition.jpg)
 
 **EP** by **[STUXNET](/project/stuxnet/)**
 Intertext · Digital

--- a/src/posts/2025-06-21-the-vulgar-fractions-error-boundary-inland-empires.md
+++ b/src/posts/2025-06-21-the-vulgar-fractions-error-boundary-inland-empires.md
@@ -3,7 +3,7 @@ title: "THE VULGAR FRACTIONS: ERROR BOUNDARY / INLAND EMPIRES"
 date: 2025-06-21
 ---
 
-![THE VULGAR FRACTIONS: ERROR BOUNDARY / INLAND EMPIRES](https://d107e1o0dn11sc.cloudfront.net/stuxnet/the-vulgar-fractions-error-boundary-inland-empires/the-vulgar-fractions-error-boundary-inland-empires.jpg)
+![THE VULGAR FRACTIONS: ERROR BOUNDARY / INLAND EMPIRES](https://assets.the-rn.info/stuxnet/the-vulgar-fractions-error-boundary-inland-empires/the-vulgar-fractions-error-boundary-inland-empires.jpg)
 
 **EP** by **[STUXNET](/project/stuxnet/)**
 Intertext · Digital

--- a/src/posts/2025-06-21-the-vulgar-fractions-pinned-in-time-like-butterflies-beneath-glass-apothecary.md
+++ b/src/posts/2025-06-21-the-vulgar-fractions-pinned-in-time-like-butterflies-beneath-glass-apothecary.md
@@ -3,7 +3,7 @@ title: "THE VULGAR FRACTIONS: PINNED IN TIME LIKE BUTTERFLIES BENEATH GLASS / AP
 date: 2025-06-21
 ---
 
-![THE VULGAR FRACTIONS: PINNED IN TIME LIKE BUTTERFLIES BENEATH GLASS / APOTHECARY](https://d107e1o0dn11sc.cloudfront.net/stuxnet/the-vulgar-fractions-pinned-in-time-like-butterflies-beneath-glass-apothecary/the-vulgar-fractions-pinned-in-time-like-butterflies-beneath-glass-apothecary.jpg)
+![THE VULGAR FRACTIONS: PINNED IN TIME LIKE BUTTERFLIES BENEATH GLASS / APOTHECARY](https://assets.the-rn.info/stuxnet/the-vulgar-fractions-pinned-in-time-like-butterflies-beneath-glass-apothecary/the-vulgar-fractions-pinned-in-time-like-butterflies-beneath-glass-apothecary.jpg)
 
 **EP** by **[STUXNET](/project/stuxnet/)**
 Intertext · Digital

--- a/src/posts/2025-06-21-the-vulgar-fractions-walkaway-hailstone-numbers.md
+++ b/src/posts/2025-06-21-the-vulgar-fractions-walkaway-hailstone-numbers.md
@@ -3,7 +3,7 @@ title: "THE VULGAR FRACTIONS: WALKAWAY / HAILSTONE NUMBERS"
 date: 2025-06-21
 ---
 
-![THE VULGAR FRACTIONS: WALKAWAY / HAILSTONE NUMBERS](https://d107e1o0dn11sc.cloudfront.net/stuxnet/the-vulgar-fractions-walkaway-hailstone-numbers/the-vulgar-fractions-walkaway-hailstone-numbers.jpg)
+![THE VULGAR FRACTIONS: WALKAWAY / HAILSTONE NUMBERS](https://assets.the-rn.info/stuxnet/the-vulgar-fractions-walkaway-hailstone-numbers/the-vulgar-fractions-walkaway-hailstone-numbers.jpg)
 
 **EP** by **[STUXNET](/project/stuxnet/)**
 Intertext · Digital

--- a/src/posts/2025-07-07-hearts-in-valencia-chapter-1.md
+++ b/src/posts/2025-07-07-hearts-in-valencia-chapter-1.md
@@ -3,7 +3,7 @@ title: "Hearts in Valencia Chapter 1"
 date: 2025-07-07
 ---
 
-![Hearts in Valencia Chapter 1](https://d107e1o0dn11sc.cloudfront.net/dj-stuxnet/hearts-in-valencia-chapter-1/hearts-in-valencia-chapter-1.jpg)
+![Hearts in Valencia Chapter 1](https://assets.the-rn.info/dj-stuxnet/hearts-in-valencia-chapter-1/hearts-in-valencia-chapter-1.jpg)
 
 **Mix** by **[DJ STUXNET](/project/dj-stuxnet/)**
 Intertext · Digital

--- a/src/posts/2025-07-17-in-breakdowns.md
+++ b/src/posts/2025-07-17-in-breakdowns.md
@@ -3,7 +3,7 @@ title: "In Breakdowns"
 date: 2025-07-17
 ---
 
-![In Breakdowns](https://d107e1o0dn11sc.cloudfront.net/dj-stuxnet/in-breakdowns/in-breakdowns.jpg)
+![In Breakdowns](https://assets.the-rn.info/dj-stuxnet/in-breakdowns/in-breakdowns.jpg)
 
 **Mix** by **[DJ STUXNET](/project/dj-stuxnet/)**
 Intertext · Digital

--- a/src/posts/2025-07-31-in-entropy.md
+++ b/src/posts/2025-07-31-in-entropy.md
@@ -3,7 +3,7 @@ title: "In Entropy"
 date: 2025-07-31
 ---
 
-![In Entropy](https://d107e1o0dn11sc.cloudfront.net/dj-stuxnet/in-entropy/in-entropy.jpg)
+![In Entropy](https://assets.the-rn.info/dj-stuxnet/in-entropy/in-entropy.jpg)
 
 **Mix** by **[DJ STUXNET](/project/dj-stuxnet/)**
 Intertext · Digital

--- a/src/posts/2025-09-05-in-ecstasy.md
+++ b/src/posts/2025-09-05-in-ecstasy.md
@@ -3,7 +3,7 @@ title: "In Ecstasy"
 date: 2025-09-05
 ---
 
-![In Ecstasy](https://d107e1o0dn11sc.cloudfront.net/dj-stuxnet/in-ecstasy/in-ecstasy.jpg)
+![In Ecstasy](https://assets.the-rn.info/dj-stuxnet/in-ecstasy/in-ecstasy.jpg)
 
 **Mix** by **[DJ STUXNET](/project/dj-stuxnet/)**
 Intertext · Digital

--- a/src/posts/2025-10-08-continuum-hack-ost.md
+++ b/src/posts/2025-10-08-continuum-hack-ost.md
@@ -3,7 +3,7 @@ title: "CONTINUUM HACK OST"
 date: 2025-10-08
 ---
 
-![CONTINUUM HACK OST](https://d107e1o0dn11sc.cloudfront.net/stuxnet/continuum-hack-ost/continuum-hack-ost.jpg)
+![CONTINUUM HACK OST](https://assets.the-rn.info/stuxnet/continuum-hack-ost/continuum-hack-ost.jpg)
 
 **OST** by **[STUXNET](/project/stuxnet/)**
 Intertext · Digital

--- a/src/posts/2025-11-06-in-abstraction-part-1.md
+++ b/src/posts/2025-11-06-in-abstraction-part-1.md
@@ -3,7 +3,7 @@ title: "In Abstraction, Part 1"
 date: 2025-11-06
 ---
 
-![In Abstraction, Part 1](https://d107e1o0dn11sc.cloudfront.net/dj-stuxnet/in-abstraction-part-1/in-abstraction-part-1.jpg)
+![In Abstraction, Part 1](https://assets.the-rn.info/dj-stuxnet/in-abstraction-part-1/in-abstraction-part-1.jpg)
 
 **Mix** by **[DJ STUXNET](/project/dj-stuxnet/)**
 Intertext · Digital

--- a/src/posts/2025-11-06-in-abstraction-part-2.md
+++ b/src/posts/2025-11-06-in-abstraction-part-2.md
@@ -3,7 +3,7 @@ title: "In Abstraction, Part 2"
 date: 2025-11-06
 ---
 
-![In Abstraction, Part 2](https://d107e1o0dn11sc.cloudfront.net/dj-stuxnet/in-abstraction-part-2/in-abstraction-part-2.jpg)
+![In Abstraction, Part 2](https://assets.the-rn.info/dj-stuxnet/in-abstraction-part-2/in-abstraction-part-2.jpg)
 
 **Mix** by **[DJ STUXNET](/project/dj-stuxnet/)**
 Intertext · Digital

--- a/src/posts/2025-11-18-hearts-in-valencia-chapter-2.md
+++ b/src/posts/2025-11-18-hearts-in-valencia-chapter-2.md
@@ -3,7 +3,7 @@ title: "Hearts in Valencia Chapter 2"
 date: 2025-11-18
 ---
 
-![Hearts in Valencia Chapter 2](https://d107e1o0dn11sc.cloudfront.net/dj-stuxnet/hearts-in-valencia-chapter-2/hearts-in-valencia-chapter-2.jpg)
+![Hearts in Valencia Chapter 2](https://assets.the-rn.info/dj-stuxnet/hearts-in-valencia-chapter-2/hearts-in-valencia-chapter-2.jpg)
 
 **Mix** by **[DJ STUXNET](/project/dj-stuxnet/)**
 Intertext · Digital

--- a/src/posts/2025-12-24-resumption.md
+++ b/src/posts/2025-12-24-resumption.md
@@ -79,7 +79,7 @@ Other than that I'm going about my usual end of year digital gardening ritual of
 
 ![the phantom mk racks](/images/phantom-racks-mk1.png)
 
-Also, I've exhumed and made available [the phantom mk racks](https://dop82cmkdnrqr.cloudfront.net/the-phantom-mk-racks.zip), a collection of Ableton Live FX racks I made for the #shadow_fi trilogy back around 2013.
+Also, I've exhumed and made available [the phantom mk racks](https://dl.the-rn.info/the-phantom-mk-racks.zip), a collection of Ableton Live FX racks I made for the #shadow_fi trilogy back around 2013.
 
 ## The Next Year
 

--- a/src/posts/2026-02-06-incendiary-nocturne.md
+++ b/src/posts/2026-02-06-incendiary-nocturne.md
@@ -3,7 +3,7 @@ title: "Incendiary Nocturne"
 date: 2026-02-06
 ---
 
-![Incendiary Nocturne](https://d107e1o0dn11sc.cloudfront.net/dj-stuxnet/incendiary-nocturne/incendiary-nocturne.jpg)
+![Incendiary Nocturne](https://assets.the-rn.info/dj-stuxnet/incendiary-nocturne/incendiary-nocturne.jpg)
 
 **Mix** by **[DJ STUXNET](/project/dj-stuxnet/)**
 Intertext · Digital

--- a/src/posts/2026-03-14-on-lying-low-until-this-singularity-thing-blows-over.md
+++ b/src/posts/2026-03-14-on-lying-low-until-this-singularity-thing-blows-over.md
@@ -106,7 +106,7 @@ I'm a musician. At the end of the day I'm here to make squiggly air and help oth
 I've been working with AI for years. One of my favorite pieces was this promo video for [Flash Crash](https://flashcrash.net). The music is original, but the video itself was from AI-generated video trained on classical (thus public domain) paintings of angels:
 
 <video width="4000" height="4000" controls="">
-  <source src="https://northerninformation.s3.us-east-2.amazonaws.com/flash-crash/fc220806.mp4" type="video/mp4">
+  <source src="https://dl.the-rn.info/flash-crash/fc220806.mp4" type="video/mp4">
   Your browser does not support the video tag.
 </video>
 

--- a/src/posts/2026-04-02-singularity-protocol.md
+++ b/src/posts/2026-04-02-singularity-protocol.md
@@ -3,7 +3,7 @@ title: "SINGULARITY PROTOCOL"
 date: 2026-04-02
 ---
 
-![SINGULARITY PROTOCOL](https://d107e1o0dn11sc.cloudfront.net/dj-stuxnet/singularity-protocol/singularity-protocol.jpg)
+![SINGULARITY PROTOCOL](https://assets.the-rn.info/dj-stuxnet/singularity-protocol/singularity-protocol.jpg)
 
 **Mix** by **[DJ STUXNET](/project/dj-stuxnet/)**
 Intertext · Digital

--- a/src/posts/2026-05-01-hearts-in-valencia-chapter-3.md
+++ b/src/posts/2026-05-01-hearts-in-valencia-chapter-3.md
@@ -3,7 +3,7 @@ title: "𝐻𝑒𝒶𝓇𝓉𝓈 𝒾𝓃 𝒱𝒶𝓁𝑒𝓃𝒸𝒾𝒶, 𝒞
 date: 2026-05-01
 ---
 
-![Hearts in Valencia, Chapter 3](https://d107e1o0dn11sc.cloudfront.net/dj-stuxnet/hearts-in-valencia-chapter-3/hearts-in-valencia-chapter-3.jpg)
+![Hearts in Valencia, Chapter 3](https://assets.the-rn.info/dj-stuxnet/hearts-in-valencia-chapter-3/hearts-in-valencia-chapter-3.jpg)
 
 **Mix** by **[DJ STUXNET](/project/dj-stuxnet/)**
 Intertext · Digital


### PR DESCRIPTION
Three commits that together migrate every AWS asset URL in this site to Cloudflare R2.

- Rewrites all source-level `https://dop82cmkdnrqr.cloudfront.net/` and direct `northerninformation.s3.us-east-2.amazonaws.com` references in posts and `src/data/` to `https://dl.the-rn.info/` — the `northerninformation` bucket (`a839079`)
- Rewrites all 72 source-level `https://d107e1o0dn11sc.cloudfront.net/` references in posts to `https://assets.the-rn.info/` — the `intertext` bucket (`2eb192a`)
- Bumps `@tyleretters/discography` from `3.0.4` to `3.0.5`, which is the version that publishes asset URLs against R2 instead of CloudFront (`d12941d`). Without this bump, anything rendered from the `discography` collection (interactive discography, embedded covers, mp3/wav zip download links, per-track audio) would still resolve to CloudFront and break after Phase 4 decommission.

All three underlying R2 buckets are provisioned, populated by Super Slurper, and verified serving via their custom domains (`assets.the-rn.info`, `dl.the-rn.info`).

External links pointing at the bare `*.cloudfront.net` hostnames (Bandcamp release notes, social posts, archive.org snapshots, etc.) will 404 once the CloudFront distributions are deleted during Phase 4. There is no way to redirect from `*.cloudfront.net` because those hostnames aren't under our control.