### PR TITLE
Use period and space between track-id sections

### DIFF
--- a/src/layouts/track-ids.njk
+++ b/src/layouts/track-ids.njk
@@ -4,32 +4,35 @@ layout: base.njk
 <div class="my-1 font-mono text-xs">
   {%- for release in collections.discography -%}
     {%- if (release.trackIds | length) > 0 -%}
-      <span class="font-bold text-yellow-300">{{ release.title }}</span>,
-      {% for track in release.trackIds -%}
-        {{- track -}}
-        {%- if not loop.last %}, {% endif -%}
-      {%- endfor -%}
-      {{- ". " -}}
+      <div class="mb-4">
+        <span class="font-bold text-yellow-300">{{ release.title }}</span>,
+        {% for track in release.trackIds -%}
+          {{- track -}}
+          {%- if not loop.last %}, {% endif -%}
+        {%- endfor -%}.
+      </div>
     {%- endif -%}
   {% endfor -%}
   {%- for release in collections.discography -%}
     {%- for track in release.tracks -%}
       {%- if (track.trackIds | length) > 0 -%}
-        <span class="font-bold text-yellow-300">{{ track.title }}</span>,
-        {% for id in track.trackIds -%}
-          {{- id -}}
-          {%- if not loop.last %}, {% endif -%}
-        {%- endfor -%}
-        {{- ". " -}}
+        <div class="mb-4">
+          <span class="font-bold text-yellow-300">{{ track.title }}</span>,
+          {% for id in track.trackIds -%}
+            {{- id -}}
+            {%- if not loop.last %}, {% endif -%}
+          {%- endfor -%}.
+        </div>
       {%- endif -%}
     {%- endfor -%}
   {%- endfor -%}
   {%- for playlist in playlists -%}
-    <span class="font-bold text-yellow-300">{{ playlist.title }}</span>,
-    {% for track in playlist.tracks -%}
-      {{- track -}}
-      {%- if not loop.last %}, {% endif -%}
-    {%- endfor -%}
-    {%- if not loop.last %}. {% endif %}
+    <div class="mb-4">
+      <span class="font-bold text-yellow-300">{{ playlist.title }}</span>,
+      {% for track in playlist.tracks -%}
+        {{- track -}}
+        {%- if not loop.last %}, {% endif -%}
+      {%- endfor -%}.
+    </div>
   {%- endfor -%}
 </div>

--- a/src/layouts/track-ids.njk
+++ b/src/layouts/track-ids.njk
@@ -9,7 +9,7 @@ layout: base.njk
         {{- track -}}
         {%- if not loop.last %}, {% endif -%}
       {%- endfor -%}
-      ,
+      {{- ". " -}}
     {%- endif -%}
   {% endfor -%}
   {%- for release in collections.discography -%}
@@ -20,8 +20,8 @@ layout: base.njk
           {{- id -}}
           {%- if not loop.last %}, {% endif -%}
         {%- endfor -%}
-        ,
-      {% endif -%}
+        {{- ". " -}}
+      {%- endif -%}
     {%- endfor -%}
   {%- endfor -%}
   {%- for playlist in playlists -%}
@@ -30,6 +30,6 @@ layout: base.njk
       {{- track -}}
       {%- if not loop.last %}, {% endif -%}
     {%- endfor -%}
-    {%- if not loop.last %}, {% endif %}
+    {%- if not loop.last %}. {% endif %}
   {%- endfor -%}
 </div>


### PR DESCRIPTION
- Replace the section terminator on `/track-ids/` with `. ` (period + space) so the last track of every release, track, and playlist block is consistently followed by a period and a space before the next title.
- Previously the three sections in `src/layouts/track-ids.njk` produced three different separators: the releases section emitted `,` with no trailing space (because `{%- endif -%}` stripped the newline before the next title), the tracks section preserved the indentation whitespace and rendered as `, `, and the playlists section had an explicit `, `.
- Switched to `{{- ". " -}}` in the releases and tracks loops, and changed the playlists conditional to `. `, so all three terminators render identically.