### PR TITLE
Add Edit link to blog posts

### DIFF
--- a/src/layouts/post.njk
+++ b/src/layouts/post.njk
@@ -6,6 +6,12 @@ layout: base.njk
     <time class="font-mono text-sm text-gray-400" datetime="{{ page.date | dateToUTCISO }}">
       {{- page.date | dateToUTCFull -}}
     </time>
+    <a
+      href="https://github.com/northern-information/nor.the-rn.info/edit/main/{{ page.inputPath | removeFirst('./') }}"
+      class="link-primary ml-2 font-mono text-sm"
+    >
+      Edit
+    </a>
     <h1 class="mb-4 text-4xl font-bold">{{ title }}</h1>
     {{ content | safe }}
   </article>


### PR DESCRIPTION
Links to the post's source markdown on GitHub via page.inputPath, placed inline after the post date.